### PR TITLE
Make the CI also do typescript check

### DIFF
--- a/.github/workflows/server_test.yml
+++ b/.github/workflows/server_test.yml
@@ -23,5 +23,7 @@ jobs:
         cache: 'yarn'
     - name: Install dependencies
       run: yarn --frozen-lockfile
+    - name: Test typescript build
+      run: yarn tsc --noEmit
     - name: Run ESLint
       run: yarn eslint ./server

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -12,7 +12,8 @@
         "removeComments": true,
         "moduleResolution": "Node",
         "esModuleInterop": true,
-        "forceConsistentCasingInFileNames": true
+        "forceConsistentCasingInFileNames": true,
+        "skipLibCheck": true // do not run type checks on *.d.ts files; prevents error from dependencies
     },
     "include": [
         "./server/**/*"


### PR DESCRIPTION
This does 2 things.

- Every pull request and new merge will be checked with `tsc --build --noEmit` alongside with the current ESLint check.
- The developers will no more get typescript error messages from the dependency modules. (`skipLibCheck` option in `tsconfig.json`)