### PR TITLE
Fix model interface to have correct ObjectId

### DIFF
--- a/server/models/reponse.ts
+++ b/server/models/reponse.ts
@@ -12,11 +12,11 @@
  * @author Eunju Jo (301170731)
  */
 
-import { model, Model, ObjectId, Schema } from "mongoose";
+import { model, Model, Schema, Types } from "mongoose";
 
  // Create an interface which TS can rely on to give use hints of what fields can be used.
  interface Response {
-    question: ObjectId; // The ID of the question this answers to
+    question: Types.ObjectId; // The ID of the question this answers to
     answers: string[];
     createdAt: Date;
 }

--- a/server/models/survey.ts
+++ b/server/models/survey.ts
@@ -12,7 +12,7 @@
  * @author Eunju Jo (301170731)
  */
 
-import { model, Model, ObjectId, Schema } from "mongoose";
+import { model, Model, Schema, Types } from "mongoose";
 
  // Create an interface which TS can rely on to give use hints of what fields can be used.
  interface Survey {
@@ -21,7 +21,7 @@ import { model, Model, ObjectId, Schema } from "mongoose";
     expiresAt?: Date;
     createdAt: Date;
     updatedAt: Date;
-    owner: ObjectId;
+    owner: Types.ObjectId;
     type: "yesno" ;
  }
 


### PR DESCRIPTION
All `ObjectId` fields in our database model interfaces had `mongoose.ObjectId` as the type. But, it turned out that this is a wrong way to implement it.

`mongoose.ObjectId` is a type definition of `mongoose.Schema.Types.ObjectId`. The schema type ObjectId is used when writing a schema definition, but what we want in our model interfaces is the actual `ObjectId` class that mongoose and mongodb use. `mongoose.Types.ObjectId` is the correct one to use in that case.