### PR TITLE
Manual activation of surveys

### DIFF
--- a/server/models/survey.ts
+++ b/server/models/survey.ts
@@ -14,17 +14,18 @@
 
 import { model, Model, Schema, Types } from "mongoose";
 
- // Create an interface which TS can rely on to give use hints of what fields can be used.
- interface Survey {
-    questions: string[]
-    title: string;
-    activeFrom: Date;
-    expiresAt?: Date;
-    createdAt: Date;
-    updatedAt: Date;
-    owner: Types.ObjectId;
-    type: "yesno" ;
- }
+// Create an interface which TS can rely on to give us hints of what fields can be used.
+interface Survey {
+   questions: string[]
+   title: string;
+   activeFrom: Date;
+   expiresAt?: Date;
+   activeOverride?: boolean;
+   createdAt: Date;
+   updatedAt: Date;
+   owner: Types.ObjectId;
+   type: "yesno" ;
+}
 
 
 // Note the type signature of the schema.
@@ -42,6 +43,10 @@ const SurveySchema = new Schema<Survey, Model<Survey>, Survey>(
         },
         expiresAt: {
             type: Date,
+            required: false,
+        },
+        activeOverride: {
+            type: Boolean,
             required: false,
         },
         owner:{

--- a/server/views/pages/account.ejs
+++ b/server/views/pages/account.ejs
@@ -38,6 +38,7 @@
           <th scope="col">Title</th>
           <th scope="col">Available From</th>
           <th scope="col">Expires At</th>
+          <th scope="col">Active Override</th>
           <th scope="col">Updated At</th>
 
 
@@ -57,13 +58,26 @@
           <td><%= survey[count].title %></td>
           <td><%= displayDate(survey[count].activeFrom) %></td>
           <td><%= displayDate(survey[count].expiresAt) %></td>
+          <td>
+            <%= typeof survey[count].activeOverride !== "boolean" ? "" :
+              survey[count].activeOverride ? "Active" : "Inactive" %>
+          </td>
           <td><%= displayDate(survey[count].updatedAt) %></td>
-          <td class="text-center"><a href="/surveyresponse/<%= survey[count]._id %>" class="btn btn-primary btn edit"><i
-            class="fas fa-edit fa-sm"></i> Results</a></td>
-          <td class="text-center"><a href="/editsurvey/<%= survey[count]._id %>" class="btn btn-primary btn edit"><i
-                class="fas fa-edit fa-sm"></i> Edit</a></td>
-          <td class="text-center"><a href="/delete/<%= survey[count]._id %>" class="btn btn-danger delete"><i
-                class="fas fa-trash-alt fa-sm"></i> Delete</a></td>
+          <td class="text-center">
+            <a href="/surveyresponse/<%= survey[count]._id %>" class="btn btn-primary btn edit">
+              <i class="fas fa-edit fa-sm"></i> Results
+            </a>
+          </td>
+          <td class="text-center">
+            <a href="/editsurvey/<%= survey[count]._id %>" class="btn btn-primary btn edit">
+              <i class="fas fa-edit fa-sm"></i> Edit
+            </a>
+          </td>
+          <td class="text-center">
+            <a href="/delete/<%= survey[count]._id %>" class="btn btn-danger delete">
+              <i class="fas fa-trash-alt fa-sm"></i> Delete
+            </a>
+          </td>
         </tr>
         <% } %>
       </tbody>

--- a/server/views/pages/editsurvey.ejs
+++ b/server/views/pages/editsurvey.ejs
@@ -30,6 +30,29 @@
         value="<%= formatDate(surveyItem.expiresAt) %>">
       <div class="col-1"></div>
     </div>
+    <div class="row justify-content-center align-items-center my-4">
+      <div class="col-10 col-lg-4 text-center text-lg-end me-4">
+        <label for="isActiveStateOverridden" class="form-label me-2 mb-2"
+          title="You can override the visibility of this survey regardless of the active/expire dates. If you check this, the value for the 'Override Value' will be used to set if your survey is visible or not.">
+          Override Active State
+        </label>
+        <input type="checkbox" class="form-check-input" name="isActiveStateOverridden" id="isActiveStateOverridden"
+          <%= typeof surveyItem.activeOverride === "boolean" ? "checked" : "" %>>
+      </div>
+      <div class="col-10 col-lg-8 row align-items-center">
+        <span class="col-12 col-lg-5 text-center text-lg-end mb-1 mb-lg-0">Override Value</span>
+        <div class="col-6 col-lg-3 text-center">
+          <input type="radio" name="activeOverride" id="activeOverrideActive" class="form-check-input" value="true"
+            <%= surveyItem.activeOverride || typeof surveyItem.activeOverride === "undefined" ? "checked" : "" %>>
+          <label for="activeOverrideActive" class="form-label">Active</label>
+        </div>
+        <div class="col-6 col-lg-3 text-center">
+          <input type="radio" name="activeOverride" id="activeOverrideInactive" class="form-check-input" value="false"
+            <%= surveyItem.activeOverride === false ? "checked" : "" %>>
+          <label for="activeOverrideInactive" class="form-label">Inactive</label>
+        </div>
+      </div>
+    </div>
     <% for(let count = 1; count < 6; count++) {%>
     <div class="row justify-content-center my-4">
       <label for="question" class="col-3 text-end"><%= count %>) Your Question</label>

--- a/server/views/pages/makesurvey.ejs
+++ b/server/views/pages/makesurvey.ejs
@@ -25,6 +25,27 @@
       <input type="date" class="col-7" id="expiresAt" placeholder="End Date" name="expiresAt">
       <div class="col-1"></div>
     </div>
+    <div class="row justify-content-center align-items-center my-4">
+      <div class="col-10 col-lg-4 text-center text-lg-end me-4">
+        <label for="isActiveStateOverridden" class="form-label me-2 mb-2"
+          title="You can override the visibility of this survey regardless of the active/expire dates. If you check this, the value for the 'Override Value' will be used to set if your survey is visible or not.">
+          Override Active State
+        </label>
+        <input type="checkbox" class="form-check-input" name="isActiveStateOverridden" id="isActiveStateOverridden">
+      </div>
+      <div class="col-10 col-lg-8 row align-items-center">
+        <span class="col-12 col-lg-5 text-center text-lg-end mb-1 mb-lg-0">Override Value</span>
+        <div class="col-6 col-lg-3 text-center">
+          <input type="radio" name="activeOverride" id="activeOverrideActive" class="form-check-input" value="true"
+            checked>
+          <label for="activeOverrideActive" class="form-label">Active</label>
+        </div>
+        <div class="col-6 col-lg-3 text-center">
+          <input type="radio" name="activeOverride" id="activeOverrideInactive" class="form-check-input" value="false">
+          <label for="activeOverrideInactive" class="form-label">Inactive</label>
+        </div>
+      </div>
+    </div>
     <% for(let count = 1; count < 6; count++) {%>
     <div class="row justify-content-center my-4">
       <label for="question" class="col-3 text-end"><%= count %>) Your Question</label>


### PR DESCRIPTION
1. Implement manual activation of surveys using `activeOverride` field in the survey model.
    `true | false` is either active or inactive (overridden). `null` or non-existing is not overridden.
2. Show the override status in the list of surveys on the account page.